### PR TITLE
synchrotron: Fix the filtering JavaScript code

### DIFF
--- a/src/web/templates/synchronization/index.html
+++ b/src/web/templates/synchronization/index.html
@@ -77,18 +77,14 @@
 
 {% block js %}
 <script type="text/javascript">
-$(window).load(function() {
-    $(document).ready(function () {
-        (function ($) {
-            $('#filter').keyup(function () {
-                var rex = new RegExp($(this).val(), 'i');
-                $('.searchable tr').hide();
-                    $('.searchable tr').filter(function () {
-                        return rex.test($(this).text());
-                    }).show();
-                })
-            }(jQuery));
-        });
+$(document).ready(function () {
+    $('#filter').keyup(function () {
+        var rex = new RegExp($(this).val(), 'i');
+        $('.searchable tr').hide();
+        $('.searchable tr').filter(function () {
+            return rex.test($(this).text());
+        }).show();
     });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
Without this patch it fails with:
```
Uncaught TypeError: $(...).load is not a function
```